### PR TITLE
Path - Alias & Merge Support

### DIFF
--- a/pkg/yamlpath/filter.go
+++ b/pkg/yamlpath/filter.go
@@ -232,6 +232,8 @@ func typedValueOfNode(node *yaml.Node) typedValue {
 		case floatTag:
 			t = floatValueType
 		}
+	} else if node.Kind == yaml.AliasNode {
+		return typedValueOfNode(node.Alias)
 	}
 
 	return typedValue{

--- a/pkg/yamlpath/path.go
+++ b/pkg/yamlpath/path.go
@@ -194,6 +194,7 @@ func empty(node, root *yaml.Node) yit.Iterator {
 	return yit.FromNodes()
 }
 
+// root is not actually the DocumentNode
 func compose(i yit.Iterator, p *Path, root *yaml.Node) yit.Iterator {
 	its := []yit.Iterator{}
 	for a, ok := i(); ok; a, ok = i() {
@@ -257,6 +258,8 @@ func propertyNameArraySubscriptThen(subscript string, p *Path) *Path {
 	})
 }
 
+// $.store
+// [?(@.price)]
 func childThen(childName string, p *Path) *Path {
 	if childName == "*" {
 		return allChildrenThen(p)
@@ -267,9 +270,15 @@ func childThen(childName string, p *Path) *Path {
 		if node.Kind != yaml.MappingNode {
 			return empty(node, root)
 		}
-		for i, n := range node.Content {
-			if i%2 == 0 && n.Value == childName {
-				return compose(yit.FromNode(node.Content[i+1]), p, root)
+
+		// Embed merge blocks, handle aliases
+		renderedMap := ProcessNode(node)
+
+		for i, n := range renderedMap.Content {
+			if i%2 == 0 {
+				if n.Value == childName {
+					return compose(yit.FromNode(renderedMap.Content[i+1]), p, root)
+				}
 			}
 		}
 		return empty(node, root)

--- a/pkg/yamlpath/path_resolved_test.go
+++ b/pkg/yamlpath/path_resolved_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package yamlpath_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
+	"gopkg.in/yaml.v3"
+)
+
+func TestResolvedFind(t *testing.T) {
+	y := `---
+store:
+  vars:
+    c: &cat fantasy
+    information: &info
+      price: 3.14
+      weight: 0.5
+    another: &another
+      price: 8
+      test: value
+    final: &fb
+      random: *cat
+  book:
+    - category: reference
+      author: Nigel Rees
+      title: Sayings of the Century
+      price: 8.95
+    - category: fiction
+      author: Evelyn Waugh
+      title: Sword of Honour
+      price: 12.99
+    - category: fiction
+      author: Herman Melville
+      title: Moby Dick
+      isbn: 0-553-21311-3
+      price: 8.99
+    - category: fiction
+      author: J. R. R. Tolkien
+      title: The Lord of the Rings
+      isbn: 0-395-19395-8
+      price: 22.99
+    - category: *cat
+      <<: *info
+      author: Something
+      title: idk man
+    - category: fiction
+      <<: [*another, *info]
+      some: thing
+    - category: non-fiction
+      <<: *fb
+      a: b
+  bicycle:
+    color: red
+    price: 19.95
+  feather duster:
+    price: 9.95
+x:
+  - y:
+    - z: 1
+      w: 2
+  - y:
+    - z: 3
+      w: 4
+test~: hello world
+test: this is a test
+`
+	var n yaml.Node
+
+	err := yaml.Unmarshal([]byte(y), &n)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		path            string
+		expectedStrings []string
+		expectedPathErr string
+		focus           bool // if true, run only tests with focus set to true
+	}{
+		{
+			name: "test using the value of an alias",
+			path: "$.store.book[?(@.category=='fantasy')]",
+			expectedStrings: []string{`category: *cat
+!!merge <<: *info
+author: Something
+title: idk man
+`,
+			},
+			expectedPathErr: "",
+		},
+		{
+			name: "test using a key within a merge",
+			path: "$.store.book[?(@.price==3.14)]",
+			expectedStrings: []string{`category: *cat
+!!merge <<: *info
+author: Something
+title: idk man
+`,
+			},
+			expectedPathErr: "",
+		},
+		{
+			name: "test using a sequence of aliases in a merge",
+			path: "$.store.book[?(@.price==8)]",
+			expectedStrings: []string{`category: fiction
+!!merge <<: [*another, *info]
+some: thing
+`,
+			},
+		},
+		{
+
+			name: "test using an alias in a merge",
+			path: "$.store.book[?(@.random=='fantasy')]",
+			expectedStrings: []string{`category: non-fiction
+!!merge <<: *fb
+a: b
+`,
+			},
+		},
+	}
+
+	focussed := false
+	for _, tc := range cases {
+		if tc.focus {
+			focussed = true
+			break
+		}
+	}
+
+	for _, tc := range cases {
+		if focussed && !tc.focus {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := yamlpath.NewPath(tc.path)
+			if err != nil {
+				require.Nil(t, p)
+			}
+			if tc.expectedPathErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedPathErr)
+				return
+			}
+
+			actual, err := p.Find(&n)
+			require.NoError(t, err)
+
+			actualStrings := []string{}
+			for _, a := range actual {
+				var buf bytes.Buffer
+				e := yaml.NewEncoder(&buf)
+				e.SetIndent(2)
+
+				err = e.Encode(a)
+				require.NoError(t, err)
+				e.Close()
+				actualStrings = append(actualStrings, buf.String())
+			}
+
+			require.Equal(t, tc.expectedStrings, actualStrings)
+		})
+	}
+
+	if focussed {
+		t.Fatalf("testcase(s) still focussed")
+	}
+}

--- a/pkg/yamlpath/resolver.go
+++ b/pkg/yamlpath/resolver.go
@@ -1,0 +1,108 @@
+package yamlpath
+
+import "gopkg.in/yaml.v3"
+
+type MergeState struct {
+	InMergeBlock bool
+	Aliases      []*yaml.Node
+}
+
+// MergeNodes will merge src -> dst while following proper YAML merge behavior
+//
+// This function will modify dst. Use a duplicate, dummy, dst node if needed.
+func MergeNodes(dst, src *yaml.Node) {
+	if dst.Kind != yaml.MappingNode || src.Kind != yaml.MappingNode {
+		return // Only merge mapping nodes
+	}
+
+	// Create a map of keys in the destination node
+	keyMap := make(map[string]int)
+	for i := 0; i < len(dst.Content); i += 2 {
+		key := dst.Content[i].Value
+		keyMap[key] = i + 1 // Store the index of the value
+	}
+
+	// Merge keys from the source node into the destination node
+	for i := 0; i < len(src.Content); i += 2 {
+		key := src.Content[i].Value
+		if key == "<<" {
+			continue // Skip merge keys as we handled them
+		}
+
+		// If the key already exists in the destination, skip it
+		// Keys in mapping nodes earlier in the sequence override keys specified in later mapping nodes
+		// Additionally, explicit keys take precedence over merge keys
+		if _, exists := keyMap[key]; exists {
+			continue
+		}
+
+		dst.Content = append(dst.Content, src.Content[i], src.Content[i+1])
+	}
+}
+
+// ProcessMappingNode will extract the mergeState if found within the given map
+//
+// Condition: node.Kind == yaml.MappingNode
+func ProcessMappingNode(node *yaml.Node, mergeState *MergeState) {
+	// Resolve aliases in the node itself
+	//if node.Kind == yaml.AliasNode {
+	//	node = node.Alias
+	//}
+
+	// Process the node's content to handle merge keys
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i]
+		if key.Value == "<<" {
+			mergeValue := node.Content[i+1]
+			if mergeValue.Kind == yaml.AliasNode {
+				// <<: *alias
+				mergeState.InMergeBlock = true
+				mergeState.Aliases = append(mergeState.Aliases, mergeValue.Alias)
+			} else if mergeValue.Kind == yaml.SequenceNode {
+				// <<: [*alias_one, *alias_two, ...]
+				for _, aliasNode := range mergeValue.Content {
+					if aliasNode.Kind == yaml.AliasNode {
+						mergeState.InMergeBlock = true
+						mergeState.Aliases = append(mergeState.Aliases, aliasNode.Alias)
+					}
+				}
+			}
+
+			// Remove the merge key and its value (don't modify the original node)
+			//node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			//i -= 2 // Adjust the index after removal
+			i += 1 // skip alias that we just dealt with
+		}
+	}
+}
+
+// ProcessNode will handle the following cases without modifying the original node:
+//
+// - yaml.AliasNode: Replacing an alias with its underlying node
+// - yaml.MappingNode: Embed any merge keys inside its node.Content (returns dummy rendered node)
+func ProcessNode(node *yaml.Node) *yaml.Node {
+	if node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+
+	// Embed merge keys if the node is a mapping node
+	if node.Kind == yaml.MappingNode {
+		var mergeState MergeState
+		ProcessMappingNode(node, &mergeState)
+
+		if mergeState.InMergeBlock {
+			mergedNode := &yaml.Node{
+				Kind:    node.Kind,
+				Content: append([]*yaml.Node{}, node.Content...), // Copy original content
+			}
+			for _, alias := range mergeState.Aliases {
+				// Ensure this node doesn't have any merges...
+				alias = ProcessNode(alias)
+				MergeNodes(mergedNode, alias)
+			}
+			node = mergedNode
+		}
+	}
+
+	return node
+}


### PR DESCRIPTION
- Path resolver can utilize alias' values and access nodes within merge keys of a mapping node.
- New test cases
- All previous test cases pass